### PR TITLE
Task/Add expense api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "thruster", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -45,5 +45,3 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 end
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.10)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -313,6 +315,7 @@ DEPENDENCIES
   debug
   kamal
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.1)
   rubocop-rails-omakase
   solid_cable

--- a/app/controllers/expense_controller.rb
+++ b/app/controllers/expense_controller.rb
@@ -1,0 +1,99 @@
+class ExpenseController < ApplicationController
+  # Obtains the expense by id before 'approve' and 'reject' actions.
+  before_action :set_expense, only: %i[ approve reject ]
+
+  # Defines the GET /expense list endpoint filtered by status and/or type.
+  def index
+    # @expenses = Expense.where(params[:status])
+    @expenses = Expense.all
+
+    # Maps the expenses array to the expected view format (including camelCase).
+    # I am sure there's a more elegant solution to accomplish this.
+    @output = @expenses.map { |expense| {
+      id: expense.id,
+      name: expense.name,
+      type: expense.type,
+      status: expense.status,
+      accommodation: expense[:hotel_name] ? {
+        hotelName: expense[:hotel_name],
+        checkInDate: expense[:check_in_date],
+        checkOutDate: expense[:check_out_date]
+      } : nil,
+      transportation: expense[:transportation_mode] ? {
+        mode: expense[:transportation_mode],
+        route: expense[:route]
+      } : nil,
+      mileage: expense.mileage,
+      amount: expense.amount,
+      createdAt: expense.created_at
+    } }
+
+    render json: @output
+  end
+
+  # Defines the POST /expense endpoint.
+  # It sets the 'pending' status by default and
+  # adapts model from request JSON body parameters.
+  def create
+    @expense = Expense.new(expense_params)
+    @expense.status = "pending"
+    @amount = params[:amount].to_f
+
+    if params[:accommodation]
+      @accommodation = params[:accommodation]
+      @expense.hotel_name = @accommodation[:hotelName]
+      @expense.check_in_date = @accommodation[:checkInDate]
+      @expense.check_out_date = @accommodation[:checkOutDate]
+    end
+
+    if params[:transportation]
+      @transportation = params[:transportation]
+      @expense.transportation_mode = @transportation[:mode]
+      @expense.route = @transportation[:route]
+    end
+
+    # For Mileage expense type, the amount is calculated
+    # based on something not defined in the project specification,
+    # so I just did some basic math.
+    if params[:mileage]
+      @mileage = params[:mileage].to_f
+      @amount = @mileage * 10
+    end
+
+    @expense.amount = @amount
+
+    if @expense.save
+      render json: { id: @expense.id() }, status: :created, location: @expense
+    else
+      render json: @expense.errors, status: :unprocessable_entity
+    end
+  end
+
+  # Defines the PATCH /expense/:id/approve endpoint.
+  # Modifies the expense's status to 'approved'.
+  def approve
+    if @expense.update(status: "approved")
+      render json: { id: @expense.id() }
+    else
+      render json: @expense.errors, status: :unprocessable_entity
+    end
+  end
+
+  # Defines the PATCH /expense/:id/reject endpoint.
+  # Modifies the expense's status to 'rejected'.
+  def reject
+    if @expense.update(status: "rejected")
+      render json: { id: @expense.id() }
+    else
+      render json: @expense.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def set_expense
+      @expense = Expense.find(params[:id])
+    end
+    def expense_params
+      params.expect(expense: [ :name, :type, :status ])
+    end
+end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -1,0 +1,10 @@
+class Expense < ApplicationRecord
+  # 'inheritance_column' is defined to allow
+  # the expense's 'type' column to be stored to db.
+  self.inheritance_column = "inheritance_type"
+
+  # Validates expense's 'name', 'type' and 'status' is present.
+  validates :name, presence: true
+  validates :type, presence: true
+  validates :status, presence: true
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+
+    resource "*",
+      headers: :any,
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  get "/expense", to: "expense#index"
+  post "/expense", to: "expense#create"
+  patch "/expense/:id/approve", to: "expense#approve"
+  patch "/expense/:id/reject", to: "expense#reject"
+
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250301164439_create_expenses.rb
+++ b/db/migrate/20250301164439_create_expenses.rb
@@ -1,0 +1,18 @@
+class CreateExpenses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :expenses do |t|
+      t.string :name
+      t.string :type
+      t.string :status
+      t.string :hotel_name
+      t.datetime :check_in_date
+      t.datetime :check_out_date
+      t.string :transportation_mode
+      t.string :route
+      t.decimal :mileage
+      t.decimal :amount
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,3 +9,26 @@
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_03_01_164439) do
+  create_table "expenses", force: :cascade do |t|
+    t.string "name"
+    t.string "type"
+    t.string "status"
+    t.string "hotel_name"
+    t.datetime "check_in_date"
+    t.datetime "check_out_date"
+    t.string "transportation_mode"
+    t.string "route"
+    t.decimal "mileage"
+    t.decimal "amount"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/test/controllers/expense_controller_test.rb
+++ b/test/controllers/expense_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExpenseControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/expenses.yml
+++ b/test/fixtures/expenses.yml
@@ -1,0 +1,67 @@
+# Define some expense fixtures. 
+
+regular:
+  name: Càmera
+  type: regular
+  status: pending
+  hotel_name: null
+  check_in_date: null
+  check_out_date: null
+  transportation_mode: null
+  route: null
+  mileage: null
+  amount: 500
+
+travel_one:
+  name: Viatge a Girona
+  type: travel
+  status: approved
+  hotel_name: Hotel Major
+  check_in_date: 2025-01-25
+  check_out_date: 2025-03-20
+  transportation_mode: null
+  route: null
+  mileage: null
+  amount: 800
+  createdAt: 1740559381
+
+travel_two:
+  name: Viatge a Andorra
+  type: travel
+  status: approved
+  hotelName: null
+  checkInDate: null
+  checkOutDate: null
+  transportation_mode: car
+  route: road
+  mileage: null
+  amount: 850
+  createdAt: 1740559381
+
+travel_three:
+  name: Viatge a Barcelona
+  type: travel
+  status: approved
+  hotelName: null
+  checkInDate: null
+  checkOutDate: null
+  transportation_mode: null
+  route: null
+  mileage: null
+  amount: 1350
+  createdAt: 1740559381
+
+mileage_three:
+  name: Ruta dels Turons
+  type: mileage
+  status: rejected
+  hotelName: null
+  checkInDate: null
+  checkOutDate: null
+  transportation_mode: null
+  route: null
+  mileage: 5000
+  amount: 150
+  createdAt: 1740664381
+
+

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,7 +1,0 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  name: MyString
-
-two:
-  name: MyString

--- a/test/models/expense_test.rb
+++ b/test/models/expense_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExpenseTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adds expense controller, model, routes, fixtures and (empty) tests.
Additionally adds `rack-cors` gem and configures CORS to allow all origins.